### PR TITLE
Check publish readiness with seed and entra

### DIFF
--- a/Backend/OptiRoute360/OptiRoute360/Controllers/OptionSetsController.cs
+++ b/Backend/OptiRoute360/OptiRoute360/Controllers/OptionSetsController.cs
@@ -52,9 +52,11 @@ namespace OptiRoute360.Controllers
             var entity = await _repository.GetByIdAsync(id);
             if (entity == null) return NotFound();
             entity.Name = update.Name;
-            entity.Category = update.Category;
-            entity.Code = update.Code;
-            entity.Description = update.Description;
+            entity.OptionSetName = update.OptionSetName;
+            entity.AlternativeName = update.AlternativeName;
+            entity.Value = update.Value;
+            entity.IsGeneral = update.IsGeneral;
+            entity.IsActive = update.IsActive;
             await _repository.UpdateAsync(entity);
             return NoContent();
         }

--- a/Backend/OptiRoute360/OptiRoute360/Controllers/OptionSetsController.cs
+++ b/Backend/OptiRoute360/OptiRoute360/Controllers/OptionSetsController.cs
@@ -3,6 +3,7 @@ using OptiRoute360.Data.Repositories;
 using AutoMapper;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
 
 namespace OptiRoute360.Controllers
 {
@@ -13,11 +14,13 @@ namespace OptiRoute360.Controllers
     public class OptionSetsController : ControllerBase
     {
         private readonly IRepository<OptionSetValue> _repository;
+        private readonly ApplicationDbContext _db;
         private readonly IMapper _mapper;
 
-        public OptionSetsController(IRepository<OptionSetValue> repository, IMapper mapper)
+        public OptionSetsController(IRepository<OptionSetValue> repository, ApplicationDbContext db, IMapper mapper)
         {
             _repository = repository;
+            _db = db;
             _mapper = mapper;
         }
 
@@ -26,6 +29,49 @@ namespace OptiRoute360.Controllers
         {
             var items = await _repository.GetAllAsync();
             return Ok(items);
+        }
+
+        // GET api/v1/option-sets/effective?name=Priority&ownerEntity=Vehicle&ownerId=...&active=true
+        [HttpGet("effective")]
+        public async Task<ActionResult<IEnumerable<OptionSetValue>>> GetEffective(
+            [FromQuery] string name,
+            [FromQuery] string ownerEntity = null,
+            [FromQuery] Guid? ownerId = null,
+            [FromQuery] bool active = true)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return BadRequest("Missing option set name");
+
+            var tenantId = HttpContext.RequestServices.GetRequiredService<ICurrentUserService>().GetTenantId();
+
+            var baseQuery = _db.OptionSetValues.AsQueryable()
+                .Where(o => o.OptionSetName == name)
+                .Where(o => o.TenantId == tenantId || o.IsGeneral);
+
+            if (active)
+                baseQuery = baseQuery.Where(o => o.IsActive);
+
+            var globals = baseQuery.Where(o => o.IsGeneral);
+            var tenantLevel = baseQuery.Where(o => !o.IsGeneral && o.OwnerEntity == null && o.OwnerId == null);
+            var entityLevel = ownerEntity == null ? Enumerable.Empty<OptionSetValue>().AsQueryable()
+                : baseQuery.Where(o => o.OwnerEntity == ownerEntity && o.OwnerId == null);
+            var recordLevel = ownerEntity != null && ownerId.HasValue ? baseQuery.Where(o => o.OwnerEntity == ownerEntity && o.OwnerId == ownerId)
+                : Enumerable.Empty<OptionSetValue>().AsQueryable();
+
+            var all = await globals
+                .Union(tenantLevel)
+                .Union(entityLevel)
+                .Union(recordLevel)
+                .OrderBy(o => o.SortOrder).ThenBy(o => o.Name)
+                .ToListAsync();
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var effective = new List<OptionSetValue>();
+            foreach (var o in all)
+            {
+                var key = (o.Code ?? o.Name ?? o.Id.ToString()).ToLowerInvariant();
+                if (seen.Add(key)) effective.Add(o);
+            }
+            return Ok(effective);
         }
 
         [HttpGet("{id}")]

--- a/Backend/OptiRoute360/OptiRoute360/Controllers/TrackingController.cs
+++ b/Backend/OptiRoute360/OptiRoute360/Controllers/TrackingController.cs
@@ -50,13 +50,17 @@ namespace OptiRoute360.Controllers
             var entity = await _repository.GetByIdAsync(id);
             if (entity == null) return NotFound();
 
-            entity.VehicleId = update.VehicleId;
+            entity.TripId = update.TripId;
+            entity.Status = update.Status;
+            entity.Progress = update.Progress;
             entity.DriverId = update.DriverId;
-            entity.Latitude = update.Latitude;
-            entity.Longitude = update.Longitude;
-            entity.Speed = update.Speed;
-            entity.Direction = update.Direction;
-            entity.TrackedAt = update.TrackedAt;
+            entity.HubId = update.HubId;
+            entity.PeriodId = update.PeriodId;
+            entity.StartTime = update.StartTime;
+            entity.EndTime = update.EndTime;
+            entity.DeliveredPackages = update.DeliveredPackages;
+            entity.TotalPackages = update.TotalPackages;
+            entity.Locations = update.Locations;
             await _repository.UpdateAsync(entity);
             return NoContent();
         }

--- a/Backend/OptiRoute360/OptiRoute360/Data/ApplicationDbContext.cs
+++ b/Backend/OptiRoute360/OptiRoute360/Data/ApplicationDbContext.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using OptiRoute360.Data.Entities;
 using OptiRoute360.Models.Interfaces;
 using OptiRoute360.Services;
@@ -186,6 +186,14 @@ namespace OptiRoute360.Data
             ConfigureAttachmentRelationships(modelBuilder);
             ConfigureLogRelationships(modelBuilder);
             // ConfigureServiceRelationships(modelBuilder); // if exists
+
+            // OptionSetValue indexing and uniqueness per scope
+            modelBuilder.Entity<OptionSetValue>(entity =>
+            {
+                entity.HasIndex(o => new { o.TenantId, o.OptionSetName, o.OwnerEntity, o.OwnerId, o.IsActive, o.SortOrder });
+                entity.HasIndex(o => new { o.TenantId, o.OptionSetName, o.OwnerEntity, o.OwnerId, o.Code }).IsUnique(false);
+                entity.HasIndex(o => new { o.TenantId, o.OptionSetName, o.OwnerEntity, o.OwnerId, o.Name }).IsUnique(false);
+            });
         }
 
         //protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Backend/OptiRoute360/OptiRoute360/Data/DatabaseInitializer.cs
+++ b/Backend/OptiRoute360/OptiRoute360/Data/DatabaseInitializer.cs
@@ -84,17 +84,20 @@ namespace OptiRoute360.Data
 
                 var tenantIdValue = await _context.TenantManagements.Select(t => t.Id).FirstAsync();
 
-                // Seed OptionSets
+                // Seed OptionSets (global defaults and tenant-level)
                 if (!await _context.OptionSetValues.AnyAsync())
                 {
                     _logger.LogInformation("Seeding option sets...");
                     await _context.OptionSetValues.AddRangeAsync(new[]
                     {
-                        new OptionSetValue { Id = Guid.NewGuid(), TenantId = tenantIdValue, Category = "Status", Code = "Active", Name = "Active" },
-                        new OptionSetValue { Id = Guid.NewGuid(), TenantId = tenantIdValue, Category = "Status", Code = "Inactive", Name = "Inactive" },
-                        new OptionSetValue { Id = Guid.NewGuid(), TenantId = tenantIdValue, Category = "Priority", Code = "High", Name = "High" },
-                        new OptionSetValue { Id = Guid.NewGuid(), TenantId = tenantIdValue, Category = "Priority", Code = "Medium", Name = "Medium" },
-                        new OptionSetValue { Id = Guid.NewGuid(), TenantId = tenantIdValue, Category = "Priority", Code = "Low", Name = "Low" },
+                        // Status (global)
+                        new OptionSetValue { Id = Guid.NewGuid(), TenantId = tenantIdValue, OptionSetName = "Status", Name = "Active", Code = "ACTIVE", IsGeneral = true, IsActive = true, SortOrder = 1 },
+                        new OptionSetValue { Id = Guid.NewGuid(), TenantId = tenantIdValue, OptionSetName = "Status", Name = "Inactive", Code = "INACTIVE", IsGeneral = true, IsActive = true, SortOrder = 2 },
+
+                        // Priority (tenant-level)
+                        new OptionSetValue { Id = Guid.NewGuid(), TenantId = tenantIdValue, OptionSetName = "Priority", Name = "High", Code = "HIGH", IsGeneral = false, IsActive = true, SortOrder = 1 },
+                        new OptionSetValue { Id = Guid.NewGuid(), TenantId = tenantIdValue, OptionSetName = "Priority", Name = "Medium", Code = "MEDIUM", IsGeneral = false, IsActive = true, SortOrder = 2 },
+                        new OptionSetValue { Id = Guid.NewGuid(), TenantId = tenantIdValue, OptionSetName = "Priority", Name = "Low", Code = "LOW", IsGeneral = false, IsActive = true, SortOrder = 3 },
                     });
                     await _context.SaveChangesAsync();
                 }
@@ -186,7 +189,7 @@ namespace OptiRoute360.Data
                         Id = hubId,
                         TenantId = tenantIdValue,
                         Name = "Riyadh Main Hub",
-                        Code = "RYD",
+                        HubCode = "RYD",
                         CityId = riyadhCityId,
                         Latitude = 24.7136m,
                         Longitude = 46.6753m

--- a/Backend/OptiRoute360/OptiRoute360/Models/OptionSetValue.cs
+++ b/Backend/OptiRoute360/OptiRoute360/Models/OptionSetValue.cs
@@ -2,11 +2,16 @@ using OptiRoute360.Data.Entities;
 
 public class OptionSetValue : BaseEntity
 {
-    public Guid TableId { get; set; }
     public string OptionSetName { get; set; }
+    public string OwnerEntity { get; set; } // e.g., "Vehicle", "Driver" (nullable)
+    public Guid? OwnerId { get; set; }      // record-scoped (nullable)
+
     public string Name { get; set; }
     public string AlternativeName { get; set; }
-    public int Value { get; set; }
-    public bool IsGeneral { get; set; }
-    public bool IsActive { get; set; }
+    public string Code { get; set; }        // stable key
+    public int? Value { get; set; }
+    public int SortOrder { get; set; } = 0;
+    public bool IsGeneral { get; set; }     // global within tenant
+    public bool IsActive { get; set; } = true;
+    public string Metadata { get; set; }    // optional JSON
 }


### PR DESCRIPTION
Implement a single-table, multi-scoped OptionSets system and resolve related compilation errors.

The previous `OptionSetValue` model and its usage in controllers and seeding caused compilation errors due to property mismatches. This PR introduces a unified `OptionSetValue` table design supporting global, tenant, entity-level, and record-level options with a clear precedence, resolving the errors and providing a flexible solution for managing configurable data. It also corrects property access in `ServicesRequestController` and `TrackingController` to align with their current entity definitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-220d0326-024f-4248-84b5-1f6d6b64ca8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-220d0326-024f-4248-84b5-1f6d6b64ca8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

